### PR TITLE
Cricket Service and API

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,6 +21,7 @@ import { TeamModule } from './services/apis/team/team.module';
 import { TeamPlayerModule } from './services/apis/teamPlayer/teamPlayer.module';
 import { GenerateOtpModule } from './services/apis/otp/generateOtp.module';
 import { MailerModule } from './services/apis/mailer/mailer.module';
+import { CricketModule } from './services/apis/cricket/cricket.module';
 
 @Module({
   imports: [
@@ -33,7 +34,7 @@ import { MailerModule } from './services/apis/mailer/mailer.module';
       connection: {
         host: process.env.REDIS_HOST,
         port: parseInt(process.env.REDIS_PORT),
-        password: process.env.REDIS_PASSWORD,
+        //password: process.env.REDIS_PASSWORD,
       },
     }),
     QueueModule,
@@ -57,6 +58,7 @@ import { MailerModule } from './services/apis/mailer/mailer.module';
     ReactionsModule,
     GenerateOtpModule,
     MailerModule,
+    CricketModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/services/apis/auth/auth.guard.ts
+++ b/src/services/apis/auth/auth.guard.ts
@@ -30,6 +30,7 @@ export class AuthGuard implements CanActivate {
     }
     const request = context.switchToHttp().getRequest();
     const token = this.extractTokenFromHeader(request);
+    console.log('token', token);
     if (!token) {
       throw new UnauthorizedException();
     }
@@ -37,9 +38,11 @@ export class AuthGuard implements CanActivate {
       const payload = await this.jwtService.verifyAsync(token, {
         secret: jwtConstants.secret,
       });
+      console.log({ payload });
       const user = await this.usersService._get(payload.sub.id);
       // 💡 We're assigning the payload to the request object here
       // so that we can access it in our route handlers
+      console.log({ user });
       if (user) {
         request['user'] = user;
         return true;

--- a/src/services/apis/cricket/cricket.controller.spec.ts
+++ b/src/services/apis/cricket/cricket.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CricketController } from './cricket.controller';
+
+describe('CricketController', () => {
+  let controller: CricketController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CricketController],
+    }).compile();
+
+    controller = module.get<CricketController>(CricketController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/services/apis/cricket/cricket.controller.ts
+++ b/src/services/apis/cricket/cricket.controller.ts
@@ -47,6 +47,31 @@ export class CricketController {
   }
 
   @Public()
+  @Get('/:matchid/event')
+  async getPreviousatestEvent(
+    @Query('id') prevEventID: string,
+    @Param('matchid') matchid: string,
+  ) {
+    const prevLatestEvent = await this.cricketService.getPreviousatestEvent(
+      matchid,
+      prevEventID,
+    );
+    return prevLatestEvent;
+  }
+
+  @Public()
+  @Get('/:matchid/event-series')
+  async getPreviousLatestEventSeries(
+    @Query('id') prevEventId: string,
+    @Param('matchid') matchid: string,
+  ) {
+    return await this.cricketService.getPreviousEventSeries(
+      matchid,
+      prevEventId,
+    );
+  }
+
+  @Public()
   @Get('/:matchid/state')
   async getLatestMatchState(@Param('matchid') matchid: string) {
     const matchState = await this.cricketService.getLatestMatchState(matchid);

--- a/src/services/apis/cricket/cricket.controller.ts
+++ b/src/services/apis/cricket/cricket.controller.ts
@@ -7,6 +7,7 @@ import {
   Patch,
   Post,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import { CricketService } from './cricket.service';
 import { ModifyBody, setCreatedBy } from 'src/decorators/ModifyBody.decorator';

--- a/src/services/apis/cricket/cricket.controller.ts
+++ b/src/services/apis/cricket/cricket.controller.ts
@@ -14,6 +14,10 @@ import { User } from '../users/decorator/user.decorator';
 import { CricketState } from './schemas/cricket.schema';
 import { CricketEvent } from './schemas/cricket.event.schema';
 import { Public } from '../auth/decorators/public.decorator';
+import {
+  updateCricketEeventDTO,
+  updateCricketEeventDTOType,
+} from './dto/cricket.event.dto';
 
 @Controller('cricket')
 export class CricketController {
@@ -76,6 +80,21 @@ export class CricketController {
   async getLatestMatchState(@Param('matchid') matchid: string) {
     const matchState = await this.cricketService.getLatestMatchState(matchid);
     return matchState;
+  }
+
+  @Patch('/event/:eventID')
+  async updateEvent(
+    @Param('eventID') eventID: string,
+    @Body() updateEventDTO: updateCricketEeventDTOType,
+  ) {
+    updateEventDTO = updateCricketEeventDTO.parse(updateEventDTO);
+    return await this.cricketService.updateEvent(eventID, updateEventDTO);
+  }
+
+  @Delete('/event/:eventID')
+  async DeleteEvent(@Param('eventID') eventID: string) {
+    const result = await this.cricketService.deleteEvent(eventID);
+    return result;
   }
 
   @Patch('/:id?')

--- a/src/services/apis/cricket/cricket.controller.ts
+++ b/src/services/apis/cricket/cricket.controller.ts
@@ -12,6 +12,7 @@ import { CricketService } from './cricket.service';
 import { ModifyBody, setCreatedBy } from 'src/decorators/ModifyBody.decorator';
 import { User } from '../users/decorator/user.decorator';
 import { CricketState } from './schemas/cricket.schema';
+import { CricketEvent } from './schemas/cricket.event.schema';
 
 @Controller('cricket')
 export class CricketController {
@@ -30,6 +31,14 @@ export class CricketController {
   @Post()
   async create(@ModifyBody(setCreatedBy()) createCricketDto: CricketState) {
     return await this.cricketService._create(createCricketDto);
+  }
+
+  @Post('/event')
+  async createEvent(
+    @ModifyBody(setCreatedBy()) createCricketEventDTO: CricketEvent,
+  ) {
+    const event = await this.cricketService.createEvent(createCricketEventDTO);
+    return event;
   }
 
   @Patch('/:id?')

--- a/src/services/apis/cricket/cricket.controller.ts
+++ b/src/services/apis/cricket/cricket.controller.ts
@@ -1,0 +1,48 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { CricketService } from './cricket.service';
+import { ModifyBody, setCreatedBy } from 'src/decorators/ModifyBody.decorator';
+import { User } from '../users/decorator/user.decorator';
+import { CricketState } from './schemas/cricket.schema';
+
+@Controller('cricket')
+export class CricketController {
+  constructor(private readonly cricketService: CricketService) {}
+
+  @Get()
+  async find(@Query() query: Record<string, any>) {
+    return await this.cricketService._find(query);
+  }
+
+  @Get('/:id?')
+  async get(@Query() query: Record<string, any>, @Param('id') id: string) {
+    return await this.cricketService._get(id, query);
+  }
+
+  @Post()
+  async create(@ModifyBody(setCreatedBy()) createCricketDto: CricketState) {
+    return await this.cricketService._create(createCricketDto);
+  }
+
+  @Patch('/:id?')
+  async patch(
+    @Query() query,
+    @Body() patchCricketDto: Partial<CricketState>,
+    @Param('id') id,
+  ) {
+    return await this.cricketService._patch(id, patchCricketDto, query);
+  }
+
+  @Delete('/:id?')
+  async delete(@Param('id') id, @Query() query, @User() user) {
+    return await this.cricketService._remove(id, query, user);
+  }
+}

--- a/src/services/apis/cricket/cricket.controller.ts
+++ b/src/services/apis/cricket/cricket.controller.ts
@@ -13,6 +13,7 @@ import { ModifyBody, setCreatedBy } from 'src/decorators/ModifyBody.decorator';
 import { User } from '../users/decorator/user.decorator';
 import { CricketState } from './schemas/cricket.schema';
 import { CricketEvent } from './schemas/cricket.event.schema';
+import { Public } from '../auth/decorators/public.decorator';
 
 @Controller('cricket')
 export class CricketController {
@@ -33,12 +34,23 @@ export class CricketController {
     return await this.cricketService._create(createCricketDto);
   }
 
-  @Post('/event')
+  @Post('/:matchid/event')
   async createEvent(
     @ModifyBody(setCreatedBy()) createCricketEventDTO: CricketEvent,
+    @Param('matchid') matchid: string,
   ) {
-    const event = await this.cricketService.createEvent(createCricketEventDTO);
+    const event = await this.cricketService.createEvent(
+      matchid,
+      createCricketEventDTO,
+    );
     return event;
+  }
+
+  @Public()
+  @Get('/:matchid/state')
+  async getLatestMatchState(@Param('matchid') matchid: string) {
+    const matchState = await this.cricketService.getLatestMatchState(matchid);
+    return matchState;
   }
 
   @Patch('/:id?')

--- a/src/services/apis/cricket/cricket.module.ts
+++ b/src/services/apis/cricket/cricket.module.ts
@@ -4,11 +4,18 @@ import { CricketController } from './cricket.controller';
 import { CricketService } from './cricket.service';
 import { CricketState, CricketStateSchema } from './schemas/cricket.schema';
 import { MatchesModule } from '../matches/matches.module';
+import {
+  CricketEvent,
+  CricketEventSchema,
+} from './schemas/cricket.event.schema';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: CricketState.name, schema: CricketStateSchema },
+    ]),
+    MongooseModule.forFeature([
+      { name: CricketEvent.name, schema: CricketEventSchema },
     ]),
     MatchesModule,
   ],

--- a/src/services/apis/cricket/cricket.module.ts
+++ b/src/services/apis/cricket/cricket.module.ts
@@ -8,6 +8,8 @@ import {
   CricketEvent,
   CricketEventSchema,
 } from './schemas/cricket.event.schema';
+import { ScoreUpdateGateway } from 'src/services/gateways/scoreUpdate/scoreUpdate';
+import { UsersModule } from '../users/users.module';
 
 @Module({
   imports: [
@@ -18,6 +20,7 @@ import {
       { name: CricketEvent.name, schema: CricketEventSchema },
     ]),
     MatchesModule,
+    UsersModule,
   ],
   controllers: [CricketController],
   providers: [CricketService],

--- a/src/services/apis/cricket/cricket.module.ts
+++ b/src/services/apis/cricket/cricket.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { CricketController } from './cricket.controller';
+import { CricketService } from './cricket.service';
+import { CricketState, CricketStateSchema } from './schemas/cricket.schema';
+import { MatchesModule } from '../matches/matches.module';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: CricketState.name, schema: CricketStateSchema },
+    ]),
+    MatchesModule,
+  ],
+  controllers: [CricketController],
+  providers: [CricketService],
+  exports: [CricketService],
+})
+export class CricketModule {}

--- a/src/services/apis/cricket/cricket.service.spec.ts
+++ b/src/services/apis/cricket/cricket.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CricketService } from './cricket.service';
+
+describe('CricketService', () => {
+  let service: CricketService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CricketService],
+    }).compile();
+
+    service = module.get<CricketService>(CricketService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/services/apis/cricket/cricket.service.ts
+++ b/src/services/apis/cricket/cricket.service.ts
@@ -3,6 +3,7 @@ import { GlobalService } from 'src/common/global-service';
 import { CricketState, CricketStateDocument } from './schemas/cricket.schema';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
+import { CricketEvent } from './schemas/cricket.event.schema';
 
 @Injectable()
 export class CricketService extends GlobalService<
@@ -12,7 +13,14 @@ export class CricketService extends GlobalService<
   constructor(
     @InjectModel(CricketState.name)
     private readonly cricketStateModel: Model<CricketStateDocument>,
+    @InjectModel(CricketEvent.name)
+    private readonly cricketEventModel: Model<CricketEvent>,
   ) {
     super(cricketStateModel);
+  }
+
+  async createEvent(createCricketEventDTO: CricketEvent) {
+    const event = await this.cricketEventModel.create(createCricketEventDTO);
+    return event;
   }
 }

--- a/src/services/apis/cricket/cricket.service.ts
+++ b/src/services/apis/cricket/cricket.service.ts
@@ -4,6 +4,7 @@ import { CricketState, CricketStateDocument } from './schemas/cricket.schema';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, Types } from 'mongoose';
 import { CricketEvent } from './schemas/cricket.event.schema';
+import { EventType } from 'src/types/EventType';
 import { create } from 'lodash';
 
 @Injectable()
@@ -41,5 +42,42 @@ export class CricketService extends GlobalService<
     });
 
     return matchStates[0];
+  }
+
+  async getPreviousatestEvent(matchID, prevEventID) {
+    const matchObjectID = new Types.ObjectId(matchID);
+    if (!prevEventID)
+      return await this.cricketEventModel
+        .find({ match: matchObjectID })
+        .sort({ createdAt: -1 });
+
+    const prevEventObjectID = new Types.ObjectId(prevEventID);
+    const TargetEvent: EventType = await this.cricketEventModel.findOne({
+      _id: prevEventObjectID,
+      match: matchObjectID,
+    });
+    const events = await this.cricketEventModel
+      .find({ match: matchObjectID, createdAt: { $lt: TargetEvent.createdAt } })
+      .sort({ createdAt: -1 });
+
+    return events[0];
+  }
+
+  async getPreviousEventSeries(matchID, prevEventID) {
+    const matchObjectId = new Types.ObjectId(matchID);
+    if (!prevEventID)
+      return await this.cricketEventModel
+        .find({ match: matchObjectId })
+        .sort({ createdAt: -1 });
+
+    const prevEventObjectID = new Types.ObjectId(prevEventID);
+    const TargetEvent: EventType = await this.cricketEventModel.findOne({
+      _id: prevEventObjectID,
+      match: matchObjectId,
+    });
+    const events = await this.cricketEventModel
+      .find({ match: matchObjectId, createdAt: { $lt: TargetEvent.createdAt } })
+      .sort({ createdAt: -1 });
+    return events;
   }
 }

--- a/src/services/apis/cricket/cricket.service.ts
+++ b/src/services/apis/cricket/cricket.service.ts
@@ -6,6 +6,7 @@ import { Model, Types } from 'mongoose';
 import { CricketEvent } from './schemas/cricket.event.schema';
 import { EventType } from 'src/types/EventType';
 import { create } from 'lodash';
+import { updateCricketEeventDTOType } from './dto/cricket.event.dto';
 
 @Injectable()
 export class CricketService extends GlobalService<
@@ -79,5 +80,22 @@ export class CricketService extends GlobalService<
       .find({ match: matchObjectId, createdAt: { $lt: TargetEvent.createdAt } })
       .sort({ createdAt: -1 });
     return events;
+  }
+
+  async updateEvent(
+    id: string,
+    updateCricketEventDTO: updateCricketEeventDTOType,
+  ) {
+    return await this.cricketEventModel.findByIdAndUpdate(
+      id,
+      updateCricketEventDTO,
+    );
+  }
+
+  async deleteEvent(id: string) {
+    const result = await this.cricketEventModel.findByIdAndDelete(id);
+    return {
+      message: 'Deleted Successfully',
+    };
   }
 }

--- a/src/services/apis/cricket/cricket.service.ts
+++ b/src/services/apis/cricket/cricket.service.ts
@@ -2,8 +2,9 @@ import { Injectable } from '@nestjs/common';
 import { GlobalService } from 'src/common/global-service';
 import { CricketState, CricketStateDocument } from './schemas/cricket.schema';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
+import { Model, Types } from 'mongoose';
 import { CricketEvent } from './schemas/cricket.event.schema';
+import { create } from 'lodash';
 
 @Injectable()
 export class CricketService extends GlobalService<
@@ -19,8 +20,26 @@ export class CricketService extends GlobalService<
     super(cricketStateModel);
   }
 
-  async createEvent(createCricketEventDTO: CricketEvent) {
-    const event = await this.cricketEventModel.create(createCricketEventDTO);
+  //Cricket class exclusive methods
+  async createEvent(matchid: string, createCricketEventDTO: CricketEvent) {
+    const event = await this.cricketEventModel.create({
+      match: matchid,
+      ...createCricketEventDTO,
+    });
     return event;
+  }
+
+  async getLatestMatchState(matchid) {
+    console.log(matchid);
+    const objectid = new Types.ObjectId(matchid);
+    const matchStates = await this.cricketStateModel
+      .find({ match: objectid })
+      .sort({ createdAt: -1 });
+
+    matchStates.forEach((state) => {
+      console.log(state.matchoutcome[0]);
+    });
+
+    return matchStates[0];
   }
 }

--- a/src/services/apis/cricket/cricket.service.ts
+++ b/src/services/apis/cricket/cricket.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { GlobalService } from 'src/common/global-service';
+import { CricketState, CricketStateDocument } from './schemas/cricket.schema';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+
+@Injectable()
+export class CricketService extends GlobalService<
+  CricketState,
+  CricketStateDocument
+> {
+  constructor(
+    @InjectModel(CricketState.name)
+    private readonly cricketStateModel: Model<CricketStateDocument>,
+  ) {
+    super(cricketStateModel);
+  }
+}

--- a/src/services/apis/cricket/dto/cricket.dto.ts
+++ b/src/services/apis/cricket/dto/cricket.dto.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import { Types } from 'mongoose';
+
+export const CreateCricketValidation = z.object({
+  name: z.string().optional(),
+  createdBy: z
+    .string()
+    .refine((val) => Types.ObjectId.isValid(val), {
+      message: 'Invalid creator ID',
+    })
+    .optional(),
+  createdAt: z.date().optional(),
+  updatedAt: z.date().optional(),
+  deleted: z.boolean().optional().default(false),
+  deletedBy: z
+    .string()
+    .refine((val) => Types.ObjectId.isValid(val), {
+      message: 'Invalid deleter ID',
+    })
+    .optional(),
+  deletedAt: z.date().optional(),
+});
+
+export const PatchCricketValidation = z.object({
+  name: z.string().optional(),
+  updatedAt: z.date().optional(),
+  createdAt: z.date().optional(),
+  deleted: z.boolean().optional(),
+  deletedBy: z
+    .string()
+    .refine((val) => Types.ObjectId.isValid(val), {
+      message: 'Invalid deleter ID',
+    })
+    .optional(),
+  deletedAt: z.date().optional(),
+});
+
+export const RemoveCricketValidation = z.object({
+  id: z.string().refine((val) => Types.ObjectId.isValid(val), {
+    message: 'Invalid user ID',
+  }),
+  deletedBy: z
+    .string()
+    .refine((val) => Types.ObjectId.isValid(val), {
+      message: 'Invalid deleter ID',
+    })
+    .optional(),
+  deletedAt: z.date().optional(),
+});
+
+export type CreateCricketDTO = z.infer<typeof CreateCricketValidation>;
+export type PatchCricketDTO = z.infer<typeof PatchCricketValidation>;
+export type RemoveCricketDTO = z.infer<typeof RemoveCricketValidation>;

--- a/src/services/apis/cricket/dto/cricket.dto.ts
+++ b/src/services/apis/cricket/dto/cricket.dto.ts
@@ -2,43 +2,220 @@ import { z } from 'zod';
 import { Types } from 'mongoose';
 
 export const CreateCricketValidation = z.object({
-  name: z.string().optional(),
-  createdBy: z
-    .string()
-    .refine((val) => Types.ObjectId.isValid(val), {
-      message: 'Invalid creator ID',
-    })
-    .optional(),
-  createdAt: z.date().optional(),
-  updatedAt: z.date().optional(),
-  deleted: z.boolean().optional().default(false),
-  deletedBy: z
-    .string()
-    .refine((val) => Types.ObjectId.isValid(val), {
-      message: 'Invalid deleter ID',
-    })
-    .optional(),
-  deletedAt: z.date().optional(),
+  match: z.string().refine((val) => Types.ObjectId.isValid(val), {
+    message: 'Not valid id',
+  }),
+
+  innings: z.object({
+    first: z.object({
+      battingTeam: z.string(),
+      totalRuns: z.number(),
+      over: z.number(),
+      wicketsFallen: z.number(),
+      Batting: z.object({
+        striker: z.object({
+          name: z.string(),
+          runs: z.number(),
+          outReason: z.string().nullable(),
+        }),
+        nonStriker: z.object({
+          name: z.string(),
+          runs: z.number(),
+          outReason: z.string().nullable(),
+        }),
+        order: z.array(
+          z.object({
+            name: z.string(),
+            runs: z.number(),
+            status: z.string(),
+            profileLink: z.string(),
+            outReason: z.array(z.string()),
+          }),
+        ),
+      }),
+      Bowling: z.object({
+        freeHit: z.boolean(),
+        bowler: z.object({
+          name: z.string(),
+          overs: z.number(),
+          runsConceded: z.number(),
+          wickets: z.number(),
+        }),
+        currentOver: z.array(
+          z.object({
+            ball: z.number(),
+            runs: z.number(),
+            illegal: z.string().nullable(),
+          }),
+        ),
+        order: z.array(
+          z.object({
+            name: z.string(),
+            overs: z.number(),
+            runsConceded: z.number(),
+            wickets: z.number(),
+            profileLink: z.string(),
+          }),
+        ),
+        extras: z.object({
+          noBalls: z.number(),
+          wides: z.number(),
+          byes: z.number(),
+          legByes: z.number(),
+        }),
+      }),
+      inningsStatus: z.string(),
+      target: z.number().nullable(),
+    }),
+    second: z.object({
+      battingTeam: z.string(),
+      totalRuns: z.number(),
+      over: z.number(),
+      wicketsFallen: z.number(),
+      Batting: z.object({
+        striker: z.string().nullable(),
+        nonStriker: z.string().nullable(),
+        order: z.array(
+          z.object({
+            name: z.string(),
+            runs: z.number(),
+            status: z.string(),
+            profileLink: z.string(),
+            outReason: z.array(z.string()),
+          }),
+        ),
+      }),
+      Bowling: z.object({
+        bowler: z.string().nullable(),
+        currentOver: z.array(z.any()),
+        extras: z.object({
+          noBalls: z.number(),
+          wides: z.number(),
+          byes: z.number(),
+          legByes: z.number(),
+        }),
+      }),
+      inningsStatus: z.string(),
+      target: z.number(),
+    }),
+  }),
+
+  interrupted: z.string(),
+  teamACaptain: z.string(),
+  teamBCaptain: z.string(),
+  teamAWicketKeeper: z.string(),
+  teamBWicketKeeper: z.string(),
+  umpires: z.array(z.string()),
+  matchStatus: z.string(),
+  macthoutcome: z.array(z.string()),
 });
 
 export const PatchCricketValidation = z.object({
-  name: z.string().optional(),
-  updatedAt: z.date().optional(),
-  createdAt: z.date().optional(),
-  deleted: z.boolean().optional(),
-  deletedBy: z
-    .string()
-    .refine((val) => Types.ObjectId.isValid(val), {
-      message: 'Invalid deleter ID',
-    })
-    .optional(),
-  deletedAt: z.date().optional(),
+  innings: z.object({
+    first: z.object({
+      battingTeam: z.string(),
+      totalRuns: z.number(),
+      over: z.number(),
+      wicketsFallen: z.number(),
+      Batting: z.object({
+        striker: z.object({
+          name: z.string(),
+          runs: z.number(),
+          outReason: z.string().nullable(),
+        }),
+        nonStriker: z.object({
+          name: z.string(),
+          runs: z.number(),
+          outReason: z.string().nullable(),
+        }),
+        order: z.array(
+          z.object({
+            name: z.string(),
+            runs: z.number(),
+            status: z.string(),
+            profileLink: z.string(),
+            outReason: z.array(z.string()),
+          }),
+        ),
+      }),
+      Bowling: z.object({
+        freeHit: z.boolean(),
+        bowler: z.object({
+          name: z.string(),
+          overs: z.number(),
+          runsConceded: z.number(),
+          wickets: z.number(),
+        }),
+        currentOver: z.array(
+          z.object({
+            ball: z.number(),
+            runs: z.number(),
+            illegal: z.string().nullable(),
+          }),
+        ),
+        order: z.array(
+          z.object({
+            name: z.string(),
+            overs: z.number(),
+            runsConceded: z.number(),
+            wickets: z.number(),
+            profileLink: z.string(),
+          }),
+        ),
+        extras: z.object({
+          noBalls: z.number(),
+          wides: z.number(),
+          byes: z.number(),
+          legByes: z.number(),
+        }),
+      }),
+      inningsStatus: z.string(),
+      target: z.number().nullable(),
+    }),
+    second: z.object({
+      battingTeam: z.string(),
+      totalRuns: z.number(),
+      over: z.number(),
+      wicketsFallen: z.number(),
+      Batting: z.object({
+        striker: z.string().nullable(),
+        nonStriker: z.string().nullable(),
+        order: z.array(
+          z.object({
+            name: z.string(),
+            runs: z.number(),
+            status: z.string(),
+            profileLink: z.string(),
+            outReason: z.array(z.string()),
+          }),
+        ),
+      }),
+      Bowling: z.object({
+        bowler: z.string().nullable(),
+        currentOver: z.array(z.any()),
+        extras: z.object({
+          noBalls: z.number(),
+          wides: z.number(),
+          byes: z.number(),
+          legByes: z.number(),
+        }),
+      }),
+      inningsStatus: z.string(),
+      target: z.number(),
+    }),
+  }),
+
+  interrupted: z.string(),
+  teamACaptain: z.string(),
+  teamBCaptain: z.string(),
+  teamAWicketKeeper: z.string(),
+  teamBWicketKeeper: z.string(),
+  umpires: z.array(z.string()),
+  matchStatus: z.string(),
+  macthoutcome: z.array(z.string()),
 });
 
 export const RemoveCricketValidation = z.object({
-  id: z.string().refine((val) => Types.ObjectId.isValid(val), {
-    message: 'Invalid user ID',
-  }),
   deletedBy: z
     .string()
     .refine((val) => Types.ObjectId.isValid(val), {

--- a/src/services/apis/cricket/dto/cricket.event.dto.ts
+++ b/src/services/apis/cricket/dto/cricket.event.dto.ts
@@ -1,4 +1,21 @@
 import { z } from 'zod';
+import { Types } from 'mongoose';
+
+export const createCricketEventDTO = z.object({
+  match: z.string().refine((val) => Types.ObjectId.isValid(val), {
+    message: 'Invalid UserID',
+  }),
+  type: z.string(),
+  details: z.object({
+    runs: z.number().nullable().optional(),
+    playerOut: z.string().nullable().optional(),
+    outReason: z.string().nullable().optional(),
+    wickets: z.number().nullable().optional(),
+    scoringType: z.number().nullable().optional(),
+    illegal: z.number().nullable().optional(),
+    penalty: z.string().nullable().optional(),
+  }),
+});
 
 export const updateCricketEeventDTO = z.object({
   type: z.string().nonempty(),
@@ -14,3 +31,4 @@ export const updateCricketEeventDTO = z.object({
 });
 
 export type updateCricketEeventDTOType = z.infer<typeof updateCricketEeventDTO>;
+export type createCricketEventDTOType = z.infer<typeof createCricketEventDTO>;

--- a/src/services/apis/cricket/dto/cricket.event.dto.ts
+++ b/src/services/apis/cricket/dto/cricket.event.dto.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const updateCricketEeventDTO = z.object({
+  type: z.string().nonempty(),
+  details: z.object({
+    runs: z.number().nullable().optional(),
+    playerOut: z.string().nullable().optional(),
+    outReason: z.array(z.any()).nullable().optional(),
+    wickets: z.number().nullable().optional(),
+    scoringType: z.string().nullable().optional(),
+    illegal: z.string().nullable().optional(),
+    penalty: z.number().nullable().optional(),
+  }),
+});
+
+export type updateCricketEeventDTOType = z.infer<typeof updateCricketEeventDTO>;

--- a/src/services/apis/cricket/schemas/cricket.event.schema.ts
+++ b/src/services/apis/cricket/schemas/cricket.event.schema.ts
@@ -1,0 +1,42 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Matches } from '../../matches/schemas/matches.schema';
+import { HydratedDocument, Types } from 'mongoose';
+import EnsureObjectId from 'src/common/EnsureObjectId';
+import { SoftDeleteSchema } from 'src/common/soft-delete-schema';
+
+export type CricketEventDocument = HydratedDocument<CricketEvent>;
+
+@Schema({
+  timestamps: true,
+})
+export class CricketEvent extends SoftDeleteSchema {
+  @Prop({
+    type: Types.ObjectId,
+    required: true,
+    index: true,
+    ref: Matches.name,
+    set: EnsureObjectId,
+  })
+  match: Types.ObjectId;
+  @Prop({
+    type: String,
+    required: true,
+  })
+  type: string;
+
+  @Prop({
+    type: Object,
+    required: true,
+  })
+  details: {
+    runs?: number | null;
+    playerOut?: string | null;
+    outReason?: any[];
+    wickets?: number | null;
+    scoringType?: number | null;
+    illegal?: string | null;
+    penalty?: number | null;
+  };
+}
+
+export const CricketEventSchema = SchemaFactory.createForClass(CricketEvent);

--- a/src/services/apis/cricket/schemas/cricket.event.schema.ts
+++ b/src/services/apis/cricket/schemas/cricket.event.schema.ts
@@ -33,7 +33,7 @@ export class CricketEvent extends SoftDeleteSchema {
     playerOut?: string | null;
     outReason?: any[];
     wickets?: number | null;
-    scoringType?: number | null;
+    scoringType?: string | null;
     illegal?: string | null;
     penalty?: number | null;
   };

--- a/src/services/apis/cricket/schemas/cricket.format.echema.ts
+++ b/src/services/apis/cricket/schemas/cricket.format.echema.ts
@@ -1,0 +1,40 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Matches } from '../../matches/schemas/matches.schema';
+import { HydratedDocument, Types } from 'mongoose';
+import EnsureObjectId from 'src/common/EnsureObjectId';
+import { SoftDeleteSchema } from 'src/common/soft-delete-schema';
+
+export type CricketFomatDocument = HydratedDocument<CricketFormat>;
+
+@Schema({
+  timestamps: true,
+})
+export class CricketFormat extends SoftDeleteSchema {
+  @Prop({
+    required: true,
+    index: true,
+    trim: true,
+  })
+  sport: string;
+
+  @Prop()
+  totalOvers: number;
+
+  @Prop()
+  powerplayOvers: number;
+
+  @Prop()
+  legalDeliveriesPerOver: number;
+
+  @Prop({
+    type: Object,
+  })
+  penaltyActions: PenaltyActions;
+
+  @Prop({
+    type: Object,
+  })
+  extraActions: ExtraActions;
+}
+
+export const CricketFormatSchema = SchemaFactory.createForClass(CricketFormat);

--- a/src/services/apis/cricket/schemas/cricket.schema.ts
+++ b/src/services/apis/cricket/schemas/cricket.schema.ts
@@ -1,0 +1,140 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Matches } from '../../matches/schemas/matches.schema';
+import { HydratedDocument, Types } from 'mongoose';
+import EnsureObjectId from 'src/common/EnsureObjectId';
+import { SoftDeleteSchema } from 'src/common/soft-delete-schema';
+
+export type CricketStateDocument = HydratedDocument<CricketState>;
+
+@Schema({
+  timestamps: true,
+})
+export class CricketState extends SoftDeleteSchema {
+  @Prop({
+    type: Types.ObjectId,
+    required: true,
+    index: true,
+    ref: Matches.name,
+    set: EnsureObjectId,
+  })
+  match: Types.ObjectId;
+  @Prop({
+    type: Object,
+    required: true,
+  })
+  innings: {
+    first: {
+      battingTeam: string;
+      totalRuns: number;
+      over: number;
+      wicketsFallen: number;
+      Batting: {
+        striker: {
+          name: string;
+          runs: number;
+          outReason: string | null;
+        };
+        nonStriker: {
+          name: string;
+          runs: number;
+          outReason: string | null;
+        };
+        order: Array<{
+          name: string;
+          runs: number;
+          status: string;
+          profileLink: string;
+          outReason: string[];
+        }>;
+      };
+      Bowling: {
+        freeHit: boolean;
+        bowler: {
+          name: string;
+          overs: number;
+          runsConceded: number;
+          wickets: number;
+        };
+        currentOver: Array<{
+          ball: number;
+          runs: number;
+          illegal: string | null;
+        }>;
+        order: Array<{
+          name: string;
+          overs: number;
+          runsConceded: number;
+          wickets: number;
+          profileLink: string;
+        }>;
+        extras: {
+          noBalls: number;
+          wides: number;
+          byes: number;
+          legByes: number;
+        };
+      };
+      inningsStatus: string;
+      target: number | null;
+    };
+    second: {
+      battingTeam: string;
+      totalRuns: number;
+      over: number;
+      wicketsFallen: number;
+      Batting: {
+        striker: string | null;
+        nonStriker: string | null;
+        order: Array<{
+          name: string;
+          runs: number;
+          status: string;
+          profileLink: string;
+          outReason: string[];
+        }>;
+      };
+      Bowling: {
+        bowler: string | null;
+        currentOver: any[];
+        extras: {
+          noBalls: number;
+          wides: number;
+          byes: number;
+          legByes: number;
+        };
+      };
+      inningsStatus: string;
+      target: number;
+    };
+  };
+
+  @Prop({ trim: true })
+  interrupted: string;
+
+  @Prop({ trim: true })
+  teamACaptain: string;
+
+  @Prop({ trim: true })
+  teamBCaptain: string;
+
+  @Prop({ trim: true })
+  teamAWicketKeeper: string;
+
+  @Prop({ trim: true })
+  teamBWicketKeeper: string;
+
+  @Prop({
+    type: [String],
+  })
+  umpires: string[];
+
+  @Prop({ trim: true })
+  matchStatus: string;
+
+  @Prop({
+    type: [String],
+  })
+  matchoutcome: string[];
+}
+
+export const CricketStateSchema = SchemaFactory.createForClass(CricketState);

--- a/src/services/apis/matches/schemas/matches.schema.ts
+++ b/src/services/apis/matches/schemas/matches.schema.ts
@@ -35,11 +35,11 @@ export class Matches {
   team2: Types.ObjectId;
 
   @Prop({
-    type: Types.ObjectId,
+    type: String,
     // ref: Sports.name // Include when sports entity is defined
     required: true,
   })
-  sport: Types.ObjectId;
+  sport: string;
 
   @Prop({
     type: String,

--- a/src/services/gateways/scoreUpdate/scoreUpdate.ts
+++ b/src/services/gateways/scoreUpdate/scoreUpdate.ts
@@ -61,6 +61,6 @@ export class ScoreUpdateGateway
   ): void {
     const matchid = client.handshake.query.matchid;
     const room = `match:${matchid}`;
-    // this.server.to(room).emit('scoreUpdate', payload);
+    // this.server.to(room).emit(clea'scoreUpdate', payload);
   }
 }

--- a/src/services/gateways/scoreUpdate/scoreUpdate.ts
+++ b/src/services/gateways/scoreUpdate/scoreUpdate.ts
@@ -1,0 +1,66 @@
+import { ConfigService } from '@nestjs/config';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { JwtService } from '@nestjs/jwt';
+import {
+  ConnectedSocket,
+  WebSocketGateway,
+  WebSocketServer,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  OnGatewayInit,
+  SubscribeMessage,
+} from '@nestjs/websockets';
+import { Server } from 'socket.io';
+import { RedisService } from 'src/services/redis/redis.service';
+import { UsersService } from 'src/services/apis/users/users.service';
+import { SocketClient } from 'src/types/SocketClient';
+import { CricketEvent } from 'src/services/apis/cricket/schemas/cricket.event.schema';
+import { Logger } from '@nestjs/common';
+
+@WebSocketGateway({
+  cors: {
+    origin: '*',
+  },
+  namespace: 'v1/score_update',
+})
+export class ScoreUpdateGateway
+  implements OnGatewayConnection, OnGatewayDisconnect, OnGatewayInit
+{
+  readonly logger = new Logger(ScoreUpdateGateway.name);
+  constructor(
+    private readonly userService: UsersService,
+    private readonly configService: ConfigService,
+    private readonly redisService: RedisService,
+    private readonly internalEventEmitter: EventEmitter2,
+  ) {}
+
+  afterInit(server: Server) {
+    this.logger.debug('initialized');
+  }
+
+  async handleConnection(client: SocketClient) {
+    console.log('Client connected');
+    const matchid = client.handshake.query.matchid;
+    const user_id = client.user._id;
+    const room = `match:${matchid}`;
+    client.join(room);
+    console.log(`User ${user_id} joined room : ${room}`);
+  }
+
+  async handleDisconnect(client: SocketClient) {
+    const matchid = client.handshake.query.matchid;
+    const room = `match:${matchid}`;
+    client.leave(room);
+    console.log(`User ${client.user._id} left room : ${room}`);
+  }
+
+  @SubscribeMessage('scoreUpdate')
+  handleScoreUpdate(
+    @ConnectedSocket() client: SocketClient,
+    payload: { cricketEvent: CricketEvent },
+  ): void {
+    const matchid = client.handshake.query.matchid;
+    const room = `match:${matchid}`;
+    // this.server.to(room).emit('scoreUpdate', payload);
+  }
+}

--- a/src/services/redis/redis.service.ts
+++ b/src/services/redis/redis.service.ts
@@ -10,7 +10,7 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
   constructor(private readonly configService: ConfigService) {}
   async onModuleInit() {
     this.client = createClient({
-      password: this.configService.get<string>('REDIS_PASSWORD'),
+      //password: this.configService.get<string>('REDIS_PASSWORD'),
       socket: {
         host: this.configService.get<string>('REDIS_HOST'),
         port: this.configService.get<number>('REDIS_PORT'),

--- a/src/types/CricketFormat.d.ts
+++ b/src/types/CricketFormat.d.ts
@@ -1,0 +1,24 @@
+enum PenaltyType {
+  no_ball = 'no_ball',
+  wide = 'wide',
+  field_obstruction = 'field_obstruction',
+  over_rate_exceeded = 'over_rate_exceeded',
+}
+
+declare type PenaltyActions = {
+  illegal: PenaltyType;
+  freeHit: boolean;
+  penalty: number;
+};
+
+enum ExtraActionsType {
+  byes = 'byes',
+  leg_byes = 'leg_byes',
+  feilding_error = 'feilding_error',
+}
+
+declare type ExtraActions = {
+  type: ExtraActionsType;
+  penalty: number;
+  description: string;
+};

--- a/src/types/EventType.d.ts
+++ b/src/types/EventType.d.ts
@@ -1,0 +1,17 @@
+import { Types } from 'mongoose';
+
+declare type EventType = {
+  match: Types.ObjectId;
+  type: string;
+  details: {
+    runs?: number | null;
+    playerOut?: string | null;
+    outReason?: any[];
+    wickets?: number | null;
+    scoringType?: string | null;
+    illegal?: string | null;
+    penalty?: number | null;
+  };
+  createdAt: Date;
+  updateAt: Date;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -430,17 +430,17 @@
 
 "@css-inline/css-inline-linux-x64-gnu@0.14.1":
   version "0.14.1"
-  resolved "https://registry.npmjs.org/@css-inline/css-inline-linux-x64-gnu/-/css-inline-linux-x64-gnu-0.14.1.tgz"
+  resolved "https://registry.yarnpkg.com/@css-inline/css-inline-linux-x64-gnu/-/css-inline-linux-x64-gnu-0.14.1.tgz#2304526e69accf7bb9b5e7c1b5af18c1c337e1a7"
   integrity sha512-yubbEye+daDY/4vXnyASAxH88s256pPati1DfVoZpU1V0+KP0BZ1dByZOU1ktExurbPH3gZOWisAnBE9xon0Uw==
 
 "@css-inline/css-inline-linux-x64-musl@0.14.1":
   version "0.14.1"
-  resolved "https://registry.npmjs.org/@css-inline/css-inline-linux-x64-musl/-/css-inline-linux-x64-musl-0.14.1.tgz"
+  resolved "https://registry.yarnpkg.com/@css-inline/css-inline-linux-x64-musl/-/css-inline-linux-x64-musl-0.14.1.tgz#9a50fe6200d3f2030f72a8af8b520c60318b3eba"
   integrity sha512-6CRAZzoy1dMLPC/tns2rTt1ZwPo0nL/jYBEIAsYTCWhfAnNnpoLKVh5Nm+fSU3OOwTTqU87UkGrFJhObD/wobQ==
 
 "@css-inline/css-inline-win32-x64-msvc@0.14.1":
   version "0.14.1"
-  resolved "https://registry.yarnpkg.com/@css-inline/css-inline-win32-x64-msvc/-/css-inline-win32-x64-msvc-0.14.1.tgz#9c269f414d44196c603033f528364a8ddf51ebc8"
+  resolved "https://registry.npmjs.org/@css-inline/css-inline-win32-x64-msvc/-/css-inline-win32-x64-msvc-0.14.1.tgz"
   integrity sha512-nzotGiaiuiQW78EzsiwsHZXbxEt6DiMUFcDJ6dhiliomXxnlaPyBfZb6/FMBgRJOf6sknDt/5695OttNmbMYzg==
 
 "@css-inline/css-inline@0.14.1":
@@ -517,7 +517,7 @@
 
 "@ioredis/commands@^1.1.1":
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"
+  resolved "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz"
   integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
 
 "@isaacs/cliui@^8.0.2":
@@ -790,7 +790,7 @@
 
 "@kafkajs/confluent-schema-registry@^2.0.1":
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@kafkajs/confluent-schema-registry/-/confluent-schema-registry-2.0.1.tgz#7a04d77bb18e3d2d1859dbf06e33d1d4a4245642"
+  resolved "https://registry.npmjs.org/@kafkajs/confluent-schema-registry/-/confluent-schema-registry-2.0.1.tgz"
   integrity sha512-sUF9kV/x1r5Iq0AzCcEqBeuHqgoMCg0FvzjwpDpKU0dj7KAozmPzGVzpejzVmB+/Z793N1ULyjNKBrRWd6QXqA==
   dependencies:
     ajv "^7.1.0"
@@ -859,7 +859,7 @@
 
 "@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3":
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz#0aa5502d547b57abfc4ac492de68e2006e417242"
+  resolved "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz"
   integrity sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==
 
 "@nestjs-modules/mailer@^2.0.2":
@@ -882,14 +882,14 @@
 
 "@nestjs/bull-shared@^10.2.3":
   version "10.2.3"
-  resolved "https://registry.yarnpkg.com/@nestjs/bull-shared/-/bull-shared-10.2.3.tgz#074749b00683e2ca10f828af21c49d4d17bd35d9"
+  resolved "https://registry.npmjs.org/@nestjs/bull-shared/-/bull-shared-10.2.3.tgz"
   integrity sha512-XcgAjNOgq6b5DVCytxhR5BKiwWo7hsusVeyE7sfFnlXRHeEtIuC2hYWBr/ZAtvL/RH0/O0tqtq0rVl972nbhJw==
   dependencies:
     tslib "2.8.1"
 
 "@nestjs/bullmq@^10.2.3":
   version "10.2.3"
-  resolved "https://registry.yarnpkg.com/@nestjs/bullmq/-/bullmq-10.2.3.tgz#1b257bdcdd139e73c39f20b7ae30660597fed3be"
+  resolved "https://registry.npmjs.org/@nestjs/bullmq/-/bullmq-10.2.3.tgz"
   integrity sha512-Lo4W5kWD61/246Y6H70RNgV73ybfRbZyKKS4CBRDaMELpxgt89O+EgYZUB4pdoNrWH16rKcaT0AoVsB/iDztKg==
   dependencies:
     "@nestjs/bull-shared" "^10.2.3"
@@ -967,7 +967,7 @@
 
 "@nestjs/microservices@^10.4.15":
   version "10.4.15"
-  resolved "https://registry.yarnpkg.com/@nestjs/microservices/-/microservices-10.4.15.tgz#9a5761145e46a9317717e06c89b84dd05fb1258b"
+  resolved "https://registry.npmjs.org/@nestjs/microservices/-/microservices-10.4.15.tgz"
   integrity sha512-t6hTvWnykF+C0mrCKJzhkyRQ8pChxrHn6Vc+mi0OViwJXzsQdRmy/m2xfQ9aeSC8B4MmGUvkK7UdH9fYbJW7gQ==
   dependencies:
     iterare "1.2.1"
@@ -1095,27 +1095,27 @@
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  resolved "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz"
   integrity sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==
 
 "@protobufjs/base64@^1.1.2":
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  resolved "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz"
   integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
 
 "@protobufjs/codegen@^2.0.4":
   version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+  resolved "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz"
   integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
 
 "@protobufjs/eventemitter@^1.1.0":
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+  resolved "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz"
   integrity sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==
 
 "@protobufjs/fetch@^1.1.0":
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  resolved "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz"
   integrity sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==
   dependencies:
     "@protobufjs/aspromise" "^1.1.1"
@@ -1123,27 +1123,27 @@
 
 "@protobufjs/float@^1.0.2":
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  resolved "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz"
   integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
 
 "@protobufjs/inquire@^1.1.0":
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  resolved "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz"
   integrity sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==
 
 "@protobufjs/path@^1.1.2":
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  resolved "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz"
   integrity sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==
 
 "@protobufjs/pool@^1.1.0":
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  resolved "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz"
   integrity sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==
 
 "@protobufjs/utf8@^1.1.0":
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+  resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
 "@redis/bloom@1.2.0":
@@ -1283,7 +1283,7 @@
 
 "@types/bcryptjs@^2.4.6":
   version "2.4.6"
-  resolved "https://registry.yarnpkg.com/@types/bcryptjs/-/bcryptjs-2.4.6.tgz#2b92e3c2121c66eba3901e64faf8bb922ec291fa"
+  resolved "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz"
   integrity sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==
 
 "@types/body-parser@*":
@@ -1406,7 +1406,7 @@
 
 "@types/long@^4.0.1":
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
+  resolved "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz"
   integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
 
 "@types/methods@^1.1.4":
@@ -1433,7 +1433,7 @@
 
 "@types/node@*", "@types/node@>=10.0.0", "@types/node@>=13.7.0", "@types/node@^22.5.2":
   version "22.10.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.10.2.tgz#a485426e6d1fdafc7b0d4c7b24e2c78182ddabb9"
+  resolved "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz"
   integrity sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==
   dependencies:
     undici-types "~6.20.0"
@@ -1507,7 +1507,7 @@
 
 "@types/validator@^13.11.8":
   version "13.12.2"
-  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.12.2.tgz#760329e756e18a4aab82fc502b51ebdfebbe49f5"
+  resolved "https://registry.npmjs.org/@types/validator/-/validator-13.12.2.tgz"
   integrity sha512-6SlHBzUW8Jhf3liqrGGXyTJSIFe4nqlJ5A5KaMZ2l/vbM3Wh3KSybots/wfWVzNLK4D1NZluDlSQIbIEPx6oyA==
 
 "@types/webidl-conversions@*":
@@ -1842,7 +1842,7 @@ ajv@^6.12.4, ajv@^6.12.5:
 
 ajv@^7.1.0:
   version "7.2.4"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-7.2.4.tgz#8e239d4d56cf884bccca8cca362f508446dc160f"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz"
   integrity sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==
   dependencies:
     fast-deep-equal "^3.1.1"
@@ -1882,7 +1882,7 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.2:
 
 ansi-escapes@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-7.0.0.tgz#00fc19f491bbb18e1d481b97868204f92109bfe7"
+  resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz"
   integrity sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==
   dependencies:
     environment "^1.0.0"
@@ -2001,7 +2001,7 @@ asynckit@^0.4.0:
 
 "avsc@>= 5.4.13 < 6":
   version "5.7.7"
-  resolved "https://registry.yarnpkg.com/avsc/-/avsc-5.7.7.tgz#8d1b5fd85904cc96a1e439450633ff33f4aff57b"
+  resolved "https://registry.npmjs.org/avsc/-/avsc-5.7.7.tgz"
   integrity sha512-9cYNccliXZDByFsFliVwk5GvTq058Fj513CiR4E60ndDwmuXzTJEp/Bp8FyuRmGyYupLjHLs+JA9/CBoVS4/NQ==
 
 babel-jest@^29.7.0:
@@ -2099,7 +2099,7 @@ bcrypt@^5.1.1:
 
 bcryptjs@^2.4.3:
   version "2.4.3"
-  resolved "https://registry.yarnpkg.com/bcryptjs/-/bcryptjs-2.4.3.tgz#9ab5627b93e60621ff7cdac5da9733027df1d0cb"
+  resolved "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz"
   integrity sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==
 
 binary-extensions@^2.0.0:
@@ -2209,11 +2209,11 @@ buffer@^5.5.0:
     ieee754 "^1.1.13"
 
 bullmq@^5.34.3:
-  version "5.34.3"
-  resolved "https://registry.yarnpkg.com/bullmq/-/bullmq-5.34.3.tgz#3fd69091c31b1139a119ecda59b4e7bc2d311638"
-  integrity sha512-S8/V11w7p6jYAGvv+00skLza/4inTOupWPe0uCD8mZSUiYKzvmW4/YEB+KVjZI2CC2oD3KJ3t7/KkUd31MxMig==
+  version "5.34.6"
+  resolved "https://registry.npmjs.org/bullmq/-/bullmq-5.34.6.tgz"
+  integrity sha512-pRCYyO9RlkQWxdmKlrNnUthyFwurYXRYLVXD1YIx+nCCdhAOiHatD8FDHbsT/w2I31c0NWoMcfZiIGuipiF7Lg==
   dependencies:
-    cron-parser "^4.6.0"
+    cron-parser "^4.9.0"
     ioredis "^5.4.1"
     msgpackr "^1.11.2"
     node-abort-controller "^3.1.1"
@@ -2323,10 +2323,15 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^5.3.0, chalk@~5.3.0:
+chalk@^5.3.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz"
   integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
+
+chalk@~5.4.1:
+  version "5.4.1"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz"
+  integrity sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==
 
 char-regex@^1.0.2:
   version "1.0.2"
@@ -2407,12 +2412,12 @@ cjs-module-lexer@^1.0.0:
 
 class-transformer@^0.5.1:
   version "0.5.1"
-  resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.5.1.tgz#24147d5dffd2a6cea930a3250a677addf96ab336"
+  resolved "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz"
   integrity sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==
 
 class-validator@^0.14.1:
   version "0.14.1"
-  resolved "https://registry.yarnpkg.com/class-validator/-/class-validator-0.14.1.tgz#ff2411ed8134e9d76acfeb14872884448be98110"
+  resolved "https://registry.npmjs.org/class-validator/-/class-validator-0.14.1.tgz"
   integrity sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==
   dependencies:
     "@types/validator" "^13.11.8"
@@ -2435,7 +2440,7 @@ cli-cursor@^3.1.0:
 
 cli-cursor@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-5.0.0.tgz#24a4831ecf5a6b01ddeb32fb71a4b2088b0dce38"
+  resolved "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz"
   integrity sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==
   dependencies:
     restore-cursor "^5.0.0"
@@ -2456,7 +2461,7 @@ cli-table3@0.6.5:
 
 cli-truncate@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-4.0.0.tgz#6cc28a2924fee9e25ce91e973db56c7066e6172a"
+  resolved "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz"
   integrity sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==
   dependencies:
     slice-ansi "^5.0.0"
@@ -2532,7 +2537,7 @@ color-support@^1.1.2:
 
 colorette@^2.0.20:
   version "2.0.20"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
+  resolved "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
 combined-stream@^1.0.8:
@@ -2564,7 +2569,7 @@ commander@^6.1.0:
 
 commander@~12.1.0:
   version "12.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
+  resolved "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz"
   integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
 
 comment-json@4.2.3:
@@ -2718,9 +2723,9 @@ create-require@^1.1.0:
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cron-parser@^4.6.0:
+cron-parser@^4.9.0:
   version "4.9.0"
-  resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-4.9.0.tgz#0340694af3e46a0894978c6f52a6dbb5c0f11ad5"
+  resolved "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz"
   integrity sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==
   dependencies:
     luxon "^3.2.1"
@@ -2777,7 +2782,7 @@ debug@4, debug@4.x, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debu
 
 debug@~4.4.0:
   version "4.4.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz"
   integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
   dependencies:
     ms "^2.1.3"
@@ -2830,7 +2835,7 @@ delegates@^1.0.0:
 
 denque@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
+  resolved "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz"
   integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
 
 depd@2.0.0:
@@ -3035,7 +3040,7 @@ emittery@^0.13.1:
 
 emoji-regex@^10.3.0:
   version "10.4.0"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.4.0.tgz#03553afea80b3975749cfcb36f776ca268e413d4"
+  resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz"
   integrity sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==
 
 emoji-regex@^8.0.0:
@@ -3120,7 +3125,7 @@ entities@^4.2.0, entities@^4.4.0, entities@^4.5.0:
 
 environment@^1.0.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/environment/-/environment-1.1.0.tgz#8e86c66b180f363c7ab311787e0259665f45a9f1"
+  resolved "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz"
   integrity sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==
 
 error-ex@^1.3.1:
@@ -3337,7 +3342,7 @@ eventemitter2@6.4.9:
 
 eventemitter3@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz"
   integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
 
 events@^3.2.0:
@@ -3375,7 +3380,7 @@ execa@^5.0.0:
 
 execa@~8.0.1:
   version "8.0.1"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-8.0.1.tgz#51f6a5943b580f963c3ca9c6321796db8cc39b8c"
+  resolved "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz"
   integrity sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==
   dependencies:
     cross-spawn "^7.0.3"
@@ -3716,7 +3721,7 @@ get-caller-file@^2.0.5:
 
 get-east-asian-width@^1.0.0:
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz#21b4071ee58ed04ee0db653371b55b4299875389"
+  resolved "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz"
   integrity sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==
 
 get-intrinsic@^1.1.3, get-intrinsic@^1.2.4:
@@ -3768,7 +3773,7 @@ get-stream@^6.0.0:
 
 get-stream@^8.0.1:
   version "8.0.1"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-8.0.1.tgz#def9dfd71742cd7754a7761ed43749a27d02eca2"
+  resolved "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz"
   integrity sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==
 
 glob-parent@^5.1.2, glob-parent@~5.1.2:
@@ -4046,12 +4051,12 @@ human-signals@^2.1.0:
 
 human-signals@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
+  resolved "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz"
   integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
 
 husky@^9.1.7:
   version "9.1.7"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.7.tgz#d46a38035d101b46a70456a850ff4201344c0b2d"
+  resolved "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz"
   integrity sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
@@ -4161,7 +4166,7 @@ inquirer@9.2.15:
 
 ioredis@^5.4.1:
   version "5.4.2"
-  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.4.2.tgz#ebb6f1a10b825b2c0fb114763d7e82114a0bee6c"
+  resolved "https://registry.npmjs.org/ioredis/-/ioredis-5.4.2.tgz"
   integrity sha512-0SZXGNGZ+WzISQ67QDyZ2x0+wVxjjUndtD8oSeik/4ajifeiRufed8fCb8QW8VMyi4MXcS+UO1k/0NGhvq1PAg==
   dependencies:
     "@ioredis/commands" "^1.1.1"
@@ -4230,12 +4235,12 @@ is-fullwidth-code-point@^3.0.0:
 
 is-fullwidth-code-point@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz#fae3167c729e7463f8461ce512b080a49268aa88"
+  resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz"
   integrity sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==
 
 is-fullwidth-code-point@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz#9609efced7c2f97da7b60145ef481c787c7ba704"
+  resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz"
   integrity sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==
   dependencies:
     get-east-asian-width "^1.0.0"
@@ -4294,7 +4299,7 @@ is-stream@^2.0.0:
 
 is-stream@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
+  resolved "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz"
   integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
 
 is-unicode-supported@^0.1.0:
@@ -4921,7 +4926,7 @@ jws@^3.2.2:
 
 kafkajs@^2.2.4:
   version "2.2.4"
-  resolved "https://registry.yarnpkg.com/kafkajs/-/kafkajs-2.2.4.tgz#59e6e16459d87fdf8b64be73970ed5aa42370a5b"
+  resolved "https://registry.npmjs.org/kafkajs/-/kafkajs-2.2.4.tgz"
   integrity sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA==
 
 kareem@2.6.3:
@@ -4976,7 +4981,7 @@ libmime@5.3.6:
 
 libphonenumber-js@^1.10.53:
   version "1.11.17"
-  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.11.17.tgz#37ddbf16dc4dd45c723a150996c253c58dad034b"
+  resolved "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.17.tgz"
   integrity sha512-Jr6v8thd5qRlOlc6CslSTzGzzQW03uiscab7KHQZX1Dfo4R6n6FDhZ0Hri6/X7edLIDv9gl4VMZXhxTjLnl0VQ==
 
 libqp@2.1.1:
@@ -4986,7 +4991,7 @@ libqp@2.1.1:
 
 lilconfig@~3.1.3:
   version "3.1.3"
-  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.3.tgz#a1bcfd6257f9585bf5ae14ceeebb7b559025e4c4"
+  resolved "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz"
   integrity sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==
 
 lines-and-columns@^1.1.6:
@@ -5002,11 +5007,11 @@ linkify-it@5.0.0:
     uc.micro "^2.0.0"
 
 lint-staged@^15.2.11:
-  version "15.2.11"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-15.2.11.tgz#e88440982f4a4c1d55a9a7a839259ec3806bd81b"
-  integrity sha512-Ev6ivCTYRTGs9ychvpVw35m/bcNDuBN+mnTeObCL5h+boS5WzBEC6LHI4I9F/++sZm1m+J2LEiy0gxL/R9TBqQ==
+  version "15.3.0"
+  resolved "https://registry.npmjs.org/lint-staged/-/lint-staged-15.3.0.tgz"
+  integrity sha512-vHFahytLoF2enJklgtOtCtIjZrKD/LoxlaUusd5nh7dWv/dkKQJY74ndFSzxCdv7g0ueGg1ORgTSt4Y9LPZn9A==
   dependencies:
-    chalk "~5.3.0"
+    chalk "~5.4.1"
     commander "~12.1.0"
     debug "~4.4.0"
     execa "~8.0.1"
@@ -5026,7 +5031,7 @@ liquidjs@^10.11.1:
 
 listr2@~8.2.5:
   version "8.2.5"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-8.2.5.tgz#5c9db996e1afeb05db0448196d3d5f64fec2593d"
+  resolved "https://registry.npmjs.org/listr2/-/listr2-8.2.5.tgz"
   integrity sha512-iyAZCeyD+c1gPyE9qpFu8af0Y+MRtmKOncdGoA2S5EY8iFq99dmmvkNnHiWo+pj0s7yH7l3KPIgee77tKpXPWQ==
   dependencies:
     cli-truncate "^4.0.0"
@@ -5057,7 +5062,7 @@ locate-path@^6.0.0:
 
 lodash.defaults@^4.2.0:
   version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  resolved "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz"
   integrity sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==
 
 lodash.includes@^4.3.0:
@@ -5067,7 +5072,7 @@ lodash.includes@^4.3.0:
 
 lodash.isarguments@^3.1.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+  resolved "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
   integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
 
 lodash.isboolean@^3.0.3:
@@ -5125,7 +5130,7 @@ log-symbols@^4.1.0:
 
 log-update@^6.1.0:
   version "6.1.0"
-  resolved "https://registry.yarnpkg.com/log-update/-/log-update-6.1.0.tgz#1a04ff38166f94647ae1af562f4bd6a15b1b7cd4"
+  resolved "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz"
   integrity sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==
   dependencies:
     ansi-escapes "^7.0.0"
@@ -5136,7 +5141,7 @@ log-update@^6.1.0:
 
 long@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  resolved "https://registry.npmjs.org/long/-/long-4.0.0.tgz"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
 lower-case@^1.1.1:
@@ -5158,7 +5163,7 @@ lru-cache@^5.1.1:
 
 luxon@^3.2.1:
   version "3.5.0"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.5.0.tgz#6b6f65c5cd1d61d1fd19dbf07ee87a50bf4b8e20"
+  resolved "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz"
   integrity sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==
 
 magic-string@0.30.8:
@@ -5221,7 +5226,7 @@ makeerror@1.0.12:
 
 "mappersmith@>= 2.30.1 < 3":
   version "2.44.0"
-  resolved "https://registry.yarnpkg.com/mappersmith/-/mappersmith-2.44.0.tgz#8ae8d6cb906cff74136ad324c2d3b23d4996a6be"
+  resolved "https://registry.npmjs.org/mappersmith/-/mappersmith-2.44.0.tgz"
   integrity sha512-YMrwxxB0fbeNk2H19jnKE6MY1Lzjt170Cml+xkOGilN8XFRykEJVjnaZoglaKKFtOaqs+4eAx+EF1vwppix8tQ==
 
 math-intrinsics@^1.0.0:
@@ -5308,12 +5313,12 @@ mimic-fn@^2.1.0:
 
 mimic-fn@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
+  resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz"
   integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
 
 mimic-function@^5.0.0:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/mimic-function/-/mimic-function-5.0.1.tgz#acbe2b3349f99b9deaca7fb70e48b83e94e67076"
+  resolved "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz"
   integrity sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==
 
 minimatch@9.0.1:
@@ -5780,7 +5785,7 @@ ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
 
 msgpackr-extract@^3.0.2:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz#e9d87023de39ce714872f9e9504e3c1996d61012"
+  resolved "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz"
   integrity sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==
   dependencies:
     node-gyp-build-optional-packages "5.2.2"
@@ -5794,7 +5799,7 @@ msgpackr-extract@^3.0.2:
 
 msgpackr@^1.11.2:
   version "1.11.2"
-  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.11.2.tgz#4463b7f7d68f2e24865c395664973562ad24473d"
+  resolved "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.2.tgz"
   integrity sha512-F9UngXRlPyWCDEASDpTf6c9uNhGPTqnTeLVt7bN+bU1eajoR/8V9ys2BRaV5C/e5ihE6sJ9uPIKaYt6bFuO32g==
   optionalDependencies:
     msgpackr-extract "^3.0.2"
@@ -5875,7 +5880,7 @@ node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
 
 node-gyp-build-optional-packages@5.2.2:
   version "5.2.2"
-  resolved "https://registry.yarnpkg.com/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz#522f50c2d53134d7f3a76cd7255de4ab6c96a3a4"
+  resolved "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz"
   integrity sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==
   dependencies:
     detect-libc "^2.0.1"
@@ -5935,7 +5940,7 @@ npm-run-path@^4.0.1:
 
 npm-run-path@^5.1.0:
   version "5.3.0"
-  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-5.3.0.tgz#e23353d0ebb9317f174e93417e4a4d82d0249e9f"
+  resolved "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz"
   integrity sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==
   dependencies:
     path-key "^4.0.0"
@@ -5995,14 +6000,14 @@ onetime@^5.1.0, onetime@^5.1.2:
 
 onetime@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-6.0.0.tgz#7c24c18ed1fd2e9bca4bd26806a33613c77d34b4"
+  resolved "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz"
   integrity sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==
   dependencies:
     mimic-fn "^4.0.0"
 
 onetime@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-7.0.0.tgz#9f16c92d8c9ef5120e3acd9dd9957cceecc1ab60"
+  resolved "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz"
   integrity sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==
   dependencies:
     mimic-function "^5.0.0"
@@ -6185,7 +6190,7 @@ path-key@^3.0.0, path-key@^3.1.0:
 
 path-key@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
+  resolved "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz"
   integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
 
 path-parse@^1.0.7:
@@ -6238,7 +6243,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
 
 pidtree@~0.6.0:
   version "0.6.0"
-  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.6.0.tgz#90ad7b6d42d5841e69e0a2419ef38f8883aa057c"
+  resolved "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz"
   integrity sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==
 
 pirates@^4.0.4:
@@ -6328,7 +6333,7 @@ proto-list@~1.2.1:
 
 protobufjs@^6.10.1:
   version "6.11.4"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.4.tgz#29a412c38bf70d89e537b6d02d904a6f448173aa"
+  resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz"
   integrity sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
@@ -6551,12 +6556,12 @@ readdirp@~3.6.0:
 
 redis-errors@^1.0.0, redis-errors@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  resolved "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz"
   integrity sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==
 
 redis-parser@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  resolved "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz"
   integrity sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==
   dependencies:
     redis-errors "^1.0.0"
@@ -6653,7 +6658,7 @@ restore-cursor@^3.1.0:
 
 restore-cursor@^5.0.0:
   version "5.1.0"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-5.1.0.tgz#0766d95699efacb14150993f55baf0953ea1ebe7"
+  resolved "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz"
   integrity sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==
   dependencies:
     onetime "^7.0.0"
@@ -6666,7 +6671,7 @@ reusify@^1.0.4:
 
 rfdc@^1.4.1:
   version "1.4.1"
-  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.4.1.tgz#778f76c4fb731d93414e8f925fbecf64cce7f6ca"
+  resolved "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz"
   integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
 
 rimraf@^3.0.2:
@@ -6872,7 +6877,7 @@ slash@^3.0.0:
 
 slice-ansi@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-5.0.0.tgz#b73063c57aa96f9cd881654b15294d95d285c42a"
+  resolved "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz"
   integrity sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==
   dependencies:
     ansi-styles "^6.0.0"
@@ -6880,7 +6885,7 @@ slice-ansi@^5.0.0:
 
 slice-ansi@^7.1.0:
   version "7.1.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-7.1.0.tgz#cd6b4655e298a8d1bdeb04250a433094b347b9a9"
+  resolved "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz"
   integrity sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==
   dependencies:
     ansi-styles "^6.2.1"
@@ -6980,7 +6985,7 @@ stack-utils@^2.0.3:
 
 standard-as-callback@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
+  resolved "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz"
   integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
 
 statuses@2.0.1:
@@ -6995,7 +7000,7 @@ streamsearch@^1.1.0:
 
 string-argv@~0.3.2:
   version "0.3.2"
-  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
+  resolved "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
 string-length@^4.0.1:
@@ -7035,7 +7040,7 @@ string-width@^5.0.1, string-width@^5.1.2:
 
 string-width@^7.0.0:
   version "7.2.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz"
   integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
   dependencies:
     emoji-regex "^10.3.0"
@@ -7099,7 +7104,7 @@ strip-final-newline@^2.0.0:
 
 strip-final-newline@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
+  resolved "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz"
   integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
 
 strip-json-comments@^3.1.1:
@@ -7356,14 +7361,14 @@ tsconfig-paths@4.2.0, tsconfig-paths@^4.1.2, tsconfig-paths@^4.2.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@2.7.0, tslib@^2.1.0, tslib@^2.6.2:
+tslib@2.7.0, tslib@^2.0.0, tslib@^2.1.0, tslib@^2.6.2:
   version "2.7.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz"
   integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
 
-tslib@2.8.1, tslib@^2.0.0:
+tslib@2.8.1:
   version "2.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 type-check@^0.4.0, type-check@~0.4.0:
@@ -7504,7 +7509,7 @@ valid-data-url@^3.0.0:
 
 validator@^13.9.0:
   version "13.12.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-13.12.0.tgz#7d78e76ba85504da3fee4fd1922b385914d4b35f"
+  resolved "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz"
   integrity sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==
 
 vary@^1, vary@~1.1.2:
@@ -7695,7 +7700,7 @@ wrap-ansi@^8.1.0:
 
 wrap-ansi@^9.0.0:
   version "9.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-9.0.0.tgz#1a3dc8b70d85eeb8398ddfb1e4a02cd186e58b3e"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz"
   integrity sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==
   dependencies:
     ansi-styles "^6.2.1"
@@ -7747,7 +7752,7 @@ yallist@^3.0.2:
 
 yaml@~2.6.1:
   version "2.6.1"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.6.1.tgz#42f2b1ba89203f374609572d5349fb8686500773"
+  resolved "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz"
   integrity sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==
 
 yargs-parser@21.1.1, yargs-parser@^21.1.1:


### PR DESCRIPTION
This PR fixes issue #26  and sets up the Cricket Service to deliver all Cricket related service routes. 

The PR creates independent entities : [CricketStates](https://psoc-docs.pages.dev/Projects/GC/Terminologies/MatchState) , [CricketEvent](https://psoc-docs.pages.dev/Projects/GC/Terminologies/MatchEvent) and [CricketFormat](https://psoc-docs.pages.dev/Projects/GC/Terminologies/MatchFormat) under the Cricket Module. 

It also creates the additional endpoints  as specified in he prior mentioned issue. All the created endpoints were tested using Postman and MongoDB Compass.

